### PR TITLE
Avoid undefined array key with PHP 8

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,7 +3,7 @@
 defined('TYPO3') or die();
 
 call_user_func(static function () {
-    if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['mw_matomo_widget'])) {
+    if (!(isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['mw_matomo_widget']))) {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['mw_matomo_widget'] = [
             'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
             'backend' => \TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class,


### PR DESCRIPTION
fix `Undefined array key "mw_matomo_widget"` warning with PHP8.